### PR TITLE
Throw Error instead of warning

### DIFF
--- a/tests/006-status.phpt
+++ b/tests/006-status.phpt
@@ -17,7 +17,11 @@ $f->resume();
 var_dump($f->status() == Fiber::STATUS_SUSPENDED);
 $f->resume();
 var_dump($f->status() == Fiber::STATUS_FINISHED);
-$f->resume();
+try {
+    $f->resume();
+} catch (Error $e) {
+    echo $e->getMessage(), PHP_EOL;
+}
 var_dump($f->status() == Fiber::STATUS_FINISHED);
 
 $f = new Fiber(function () {
@@ -33,7 +37,6 @@ var_dump($f->status() == Fiber::STATUS_DEAD);
 bool(true)
 bool(true)
 bool(true)
-
-Warning: Attempt to resume non suspended Fiber in %s006.php on line %d
+Attempt to resume non suspended Fiber
 bool(true)
 bool(true)

--- a/tests/007-uncaught-error.phpt
+++ b/tests/007-uncaught-error.phpt
@@ -27,10 +27,10 @@ $f->resume();
 
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Call to a member function foo() on null in %s%e007.php:6
+Fatal error: Uncaught Error: Call to a member function foo() on null in %s%e007-uncaught-error.php:6
 Stack trace:
-#0 %s%e007.php(10): bar()
-#1 %s%e007.php(13): foo()
+#0 %s%e007-uncaught-error.php(10): bar()
+#1 %s%e007-uncaught-error.php(13): foo()
 #2 (0): {closure}()
 #3 {main}
-  thrown in %s%e007.php on line 6
+  thrown in %s%e007-uncaught-error.php on line 6

--- a/tests/009-yield-outside-fiber.phpt
+++ b/tests/009-yield-outside-fiber.phpt
@@ -11,8 +11,8 @@ if (!extension_loaded('fiber')) {
 Fiber::yield();
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Cannot call Fiber::yield out of Fiber in %s%etests%e009.php:%d
+Fatal error: Uncaught Error: Cannot call Fiber::yield out of Fiber in %s%etests%e009-yield-outside-fiber.php:%d
 Stack trace:
-#0 %s%etests%e009.php(%d): Fiber::yield()
+#0 %s%etests%e009-yield-outside-fiber.php(%d): Fiber::yield()
 #1 {main}
-  thrown in %s%etests%e009.php on line %d
+  thrown in %s%etests%e009-yield-outside-fiber.php on line %d

--- a/tests/011-reset-unfinished.phpt
+++ b/tests/011-reset-unfinished.phpt
@@ -30,8 +30,8 @@ $f->reset();
 --EXPECTF--
 1
 
-Fatal error: Uncaught Error: Cannot reset unfinished Fiber in %s%e011.php:19
+Fatal error: Uncaught Error: Cannot reset unfinished Fiber in %s%e011-reset-unfinished.php:19
 Stack trace:
-#0 %s%e011.php(19): Fiber->reset()
+#0 %s%e011-reset-unfinished.php(19): Fiber->reset()
 #1 {main}
-  thrown in %s%e011.php on line 19
+  thrown in %s%e011-reset-unfinished.php on line 19

--- a/tests/017-exception-on-resume.phpt
+++ b/tests/017-exception-on-resume.phpt
@@ -32,6 +32,6 @@ try {
 }
 ?>
 --EXPECTF--
-#0 %s/tests/017.php(11): foo()
+#0 %s/tests/017-exception-on-resume.php(11): foo()
 #1 (0): bar()
 #2 {main}

--- a/tests/018-construct-with-non-callable.phpt
+++ b/tests/018-construct-with-non-callable.phpt
@@ -12,8 +12,8 @@ $f = new Fiber;
 $f->resume();
 ?>
 --EXPECTF--
-Fatal error: Uncaught Error: Attempt to start non callable Fiber, no array or string given in %s/tests/018.php:3
+Fatal error: Uncaught Error: Attempt to start non callable Fiber, no array or string given in %s/tests/018-construct-with-non-callable.php:3
 Stack trace:
-#0 %s/tests/018.php(3): Fiber->resume()
+#0 %s/tests/018-construct-with-non-callable.php(3): Fiber->resume()
 #1 {main}
-  thrown in %s/tests/018.php on line 3
+  thrown in %s/tests/018-construct-with-non-callable.php on line 3

--- a/tests/018-construct-with-non-callable.phpt
+++ b/tests/018-construct-with-non-callable.phpt
@@ -12,4 +12,8 @@ $f = new Fiber;
 $f->resume();
 ?>
 --EXPECTF--
-Warning: Attempt to start non callable Fiber, no array or string given in %s/tests/018.php on line 3
+Fatal error: Uncaught Error: Attempt to start non callable Fiber, no array or string given in %s/tests/018.php:3
+Stack trace:
+#0 %s/tests/018.php(3): Fiber->resume()
+#1 {main}
+  thrown in %s/tests/018.php on line 3

--- a/tests/020-resume-with-too-few-arguments.phpt
+++ b/tests/020-resume-with-too-few-arguments.phpt
@@ -14,8 +14,8 @@ $f = new Fiber(function ($a) {
 $f->resume();
 ?>
 --EXPECTF--
-Fatal error: Uncaught ArgumentCountError: Too few arguments for callable given to Fiber, 1 required, 0 given in %s/tests/020.php:5
+Fatal error: Uncaught ArgumentCountError: Too few arguments for callable given to Fiber, 1 required, 0 given in %s/tests/020-resume-with-too-few-arguments.php:5
 Stack trace:
-#0 %s/tests/020.php(5): Fiber->resume()
+#0 %s/tests/020-resume-with-too-few-arguments.php(5): Fiber->resume()
 #1 {main}
-  thrown in %s/tests/020.php on line 5
+  thrown in %s/tests/020-resume-with-too-few-arguments.php on line 5

--- a/tests/020-resume-with-too-few-arguments.phpt
+++ b/tests/020-resume-with-too-few-arguments.phpt
@@ -1,0 +1,21 @@
+--TEST--
+test too few arguments to resume
+--SKIPIF--
+<?php
+if (!extension_loaded('fiber')) {
+    echo 'skip';
+}
+?>
+--FILE--
+<?php
+$f = new Fiber(function ($a) {
+    Fiber::yield($a);
+});
+$f->resume();
+?>
+--EXPECTF--
+Fatal error: Uncaught ArgumentCountError: Too few arguments for callable given to Fiber, 1 required, 0 given in %s/tests/020.php:5
+Stack trace:
+#0 %s/tests/020.php(5): Fiber->resume()
+#1 {main}
+  thrown in %s/tests/020.php on line 5


### PR DESCRIPTION
Warnings seem inappropriate here, as the behavior is not at all going to be what is expected and is unrecoverable. Most similar conditions in core now throw Error. Similar ops on `Generator` also throw if conditions are not met.

I also added some code to validate the number of arguments given to `Fiber::resume()` matches that expected by the callable.

Why is the callable to `Fiber::__construct()` optional? Is there a reason to create fiber without a callable?